### PR TITLE
staking: add test cases & small fixes

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -11,6 +11,6 @@ cluster = "localnet"
 wallet = "~/.config/solana/id.json"
 
 [programs.localnet]
-staking = "FFkqjHsFZS3MaUELNrz4TMNo1pz5nE3sBShjuMiSy1Pz"
+staking = "DNTDdX18wZCfRWzB6auDDi8CqX3TQTLSZGd8LwTpusNL"
 single_farming = "EnkQuN7PGSdvqDmB9Z1dDRKuYnXnCeEMpUwHU37E3kQd"
 dual_farming = "AXFHikQNKk2zgiss9USaUVccLt4TSqmXBLEkZZ6GhojH"

--- a/cli/dual-farming-cli/README.MD
+++ b/cli/dual-farming-cli/README.MD
@@ -115,10 +115,10 @@ Program ID: "AXFHikQNKk2zgiss9USaUVccLt4TSqmXBLEkZZ6GhojH"
 Signature 5T8YCrxJkVE238tnDABdhoeVyL5u9kR2EqaAV8KPB6yFefZtAH8nwwEd3BBtiGXYH5NKW2eXju6HByQbj2kvR2ax
 ```
 
-### Stake
+### Deposit
 
 ```bash
-./dual-farming-cli stake --wallet-path ~/.config/solana/user.json  --staking-mint AtssC9B1jGqW4d2PVZmMt6cLLpQ84DycLpAae7EW3XL6 --base 6iG7xBbKbkm14yQfJjBJ6YZR6uHNbdw6eNnrCGQ8RsUF 1000
+./dual-farming-cli deposit --wallet-path ~/.config/solana/user.json  --staking-mint AtssC9B1jGqW4d2PVZmMt6cLLpQ84DycLpAae7EW3XL6 --base 6iG7xBbKbkm14yQfJjBJ6YZR6uHNbdw6eNnrCGQ8RsUF 1000
 
 
 Wallet EdRCHLTZR6Pcx1YDa4TgvVoxJDkCuwwvDGYSh9LNy5KK
@@ -127,10 +127,10 @@ Signature 57tnZedp4qZzsYCmss64kyqDWM8BvgexLvc5yEPZyw4gETGqbCbCQG3v3ridyKgwHnWZCN
 
 ```
 
-### Unstake
+### Withdraw
 
 ```bash
-./dual-farming-cli unstake [--wallet-path <WALLET_PATH_JSON>]  --staking-mint <STAKING_MINT_PUBKEY> --base <BASE_PUBKEY> amount
+./dual-farming-cli withdraw [--wallet-path <WALLET_PATH_JSON>]  --staking-mint <STAKING_MINT_PUBKEY> --base <BASE_PUBKEY> amount
 ```
 
 

--- a/cli/dual-farming-cli/src/args.rs
+++ b/cli/dual-farming-cli/src/args.rs
@@ -85,7 +85,7 @@ pub enum CliCommand {
         base: Pubkey,
     },
     /// User stakes
-    Stake {
+    Deposit {
         #[clap(long)]
         staking_mint: Pubkey,
         #[clap(long)]
@@ -93,7 +93,7 @@ pub enum CliCommand {
         amount: u64,
     },
     /// User unstakes
-    Unstake {
+    Withdraw {
         #[clap(long)]
         staking_mint: Pubkey,
         #[clap(long)]

--- a/cli/dual-farming-cli/src/main.rs
+++ b/cli/dual-farming-cli/src/main.rs
@@ -56,14 +56,14 @@ fn main() -> Result<()> {
         CliCommand::Unpause { staking_mint, base } => {
             unpause(&program, &payer, &staking_mint, &base)?;
         }
-        CliCommand::Stake {
+        CliCommand::Deposit {
             staking_mint,
             base,
             amount,
         } => {
             stake(&program, &payer, &staking_mint, &base, amount)?;
         }
-        CliCommand::Unstake {
+        CliCommand::Withdraw {
             staking_mint,
             base,
             spt_amount,
@@ -238,7 +238,7 @@ pub fn stake(
 
     let builder = program
         .request()
-        .accounts(dual_farming::accounts::Stake {
+        .accounts(dual_farming::accounts::Deposit {
             pool: pool_pda.pubkey,
             staking_vault: pool.staking_vault,
             stake_from_account,
@@ -246,7 +246,7 @@ pub fn stake(
             owner: owner.pubkey(),
             token_program: spl_token::ID,
         })
-        .args(dual_farming::instruction::Stake { amount })
+        .args(dual_farming::instruction::Deposit { amount })
         .signer(owner);
     let signature = builder.send()?;
     println!("Signature {:?}", signature);
@@ -269,7 +269,7 @@ pub fn unstake(
 
     let builder = program
         .request()
-        .accounts(dual_farming::accounts::Stake {
+        .accounts(dual_farming::accounts::Deposit {
             pool: pool_pda.pubkey,
             staking_vault: pool.staking_vault,
             user: user_pubkey,
@@ -277,7 +277,7 @@ pub fn unstake(
             owner: owner.pubkey(),
             token_program: spl_token::ID,
         })
-        .args(dual_farming::instruction::Unstake { spt_amount })
+        .args(dual_farming::instruction::Withdraw { spt_amount })
         .signer(owner);
     let signature = builder.send()?;
     println!("Signature {:?}", signature);

--- a/cli/single-farming-cli/src/main.rs
+++ b/cli/single-farming-cli/src/main.rs
@@ -166,7 +166,7 @@ pub fn stake(program: &Program, owner: &Keypair, staking_mint: &Pubkey, amount: 
 
     let builder = program
         .request()
-        .accounts(single_farming::accounts::Stake {
+        .accounts(single_farming::accounts::Deposit {
             pool: pool_pda.pubkey,
             staking_vault: pool.staking_vault,
             stake_from_account,
@@ -174,7 +174,7 @@ pub fn stake(program: &Program, owner: &Keypair, staking_mint: &Pubkey, amount: 
             owner: owner.pubkey(),
             token_program: spl_token::ID,
         })
-        .args(single_farming::instruction::Stake { amount })
+        .args(single_farming::instruction::Deposit { amount })
         .signer(owner);
     let signature = builder.send()?;
     println!("Signature {:?}", signature);
@@ -196,7 +196,7 @@ pub fn unstake(
 
     let builder = program
         .request()
-        .accounts(single_farming::accounts::Stake {
+        .accounts(single_farming::accounts::Deposit {
             pool: pool_pda.pubkey,
             staking_vault: pool.staking_vault,
             user: user_pubkey,
@@ -204,7 +204,7 @@ pub fn unstake(
             owner: owner.pubkey(),
             token_program: spl_token::ID,
         })
-        .args(single_farming::instruction::Unstake { spt_amount })
+        .args(single_farming::instruction::Withdraw { spt_amount })
         .signer(owner);
     let signature = builder.send()?;
     println!("Signature {:?}", signature);

--- a/cli/staking-cli/src/main.rs
+++ b/cli/staking-cli/src/main.rs
@@ -304,7 +304,7 @@ fn initialize_vault(
             system_program: system_program::ID,
             token_program: spl_token::ID,
         })
-        .args(staking::instruction::InitializeVault { vault_bump })
+        .args(staking::instruction::InitializeVault {})
         .signer(admin)
         .signer(&base_keypair);
 

--- a/programs/single-farming/src/lib.rs
+++ b/programs/single-farming/src/lib.rs
@@ -147,14 +147,14 @@ pub mod single_farming {
         Ok(())
     }
 
-    /// A user stakes all tokens into the pool.
-    pub fn stake_full(ctx: Context<Stake>) -> Result<()> {
+    /// A user deposit all tokens into the pool.
+    pub fn deposit_full(ctx: Context<Deposit>) -> Result<()> {
         let full_amount = ctx.accounts.stake_from_account.amount;
-        stake(ctx, full_amount)
+        deposit(ctx, full_amount)
     }
 
-    /// A user stakes tokens in the pool.
-    pub fn stake(ctx: Context<Stake>, amount: u64) -> Result<()> {
+    /// A user deposit tokens in the pool.
+    pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {
         if amount == 0 {
             return Err(ErrorCode::AmountMustBeGreaterThanZero.into());
         }
@@ -183,8 +183,8 @@ pub mod single_farming {
         Ok(())
     }
 
-    /// A user unstakes tokens in the pool.
-    pub fn unstake(ctx: Context<Stake>, spt_amount: u64) -> Result<()> {
+    /// A user withdraw tokens in the pool.
+    pub fn withdraw(ctx: Context<Deposit>, spt_amount: u64) -> Result<()> {
         if spt_amount == 0 {
             return Err(ErrorCode::AmountMustBeGreaterThanZero.into());
         }
@@ -370,9 +370,9 @@ pub struct CreateUser<'info> {
     pub system_program: Program<'info, System>,
 }
 
-/// Accounts for [Stake](/single_farming/instruction/struct.Stake.html) instruction and [UnStake](/single_farming/instruction/struct.Unstake.html) instruction
+/// Accounts for [Deposit](/single_farming/instruction/struct.Deposit.html) instruction and [Withdraw](/single_farming/instruction/struct.Withdraw.html) instruction
 #[derive(Accounts)]
-pub struct Stake<'info> {
+pub struct Deposit<'info> {
     /// The farming pool PDA.
     #[account(
         mut,

--- a/tests/dual-farming/dual-farming.ts
+++ b/tests/dual-farming/dual-farming.ts
@@ -31,7 +31,7 @@ const TOKEN_DECIMAL = 3;
 const TOKEN_MULTIPLIER = new anchor.BN(10 ** TOKEN_DECIMAL);
 const MINT_AMOUNT = new anchor.BN(100_000).mul(TOKEN_MULTIPLIER);
 const FUND_AMOUNT = new anchor.BN(10_000).mul(TOKEN_MULTIPLIER);
-const STAKE_AMOUNT = new anchor.BN(500).mul(TOKEN_MULTIPLIER);
+const DEPOSIT_AMOUNT = new anchor.BN(500).mul(TOKEN_MULTIPLIER);
 const UNSTAKE_AMOUNT = new anchor.BN(500).mul(TOKEN_MULTIPLIER);
 
 function sleep(ms: number) {
@@ -388,7 +388,7 @@ describe("dual-farming", () => {
     assert.deepStrictEqual(poolState.rewardDurationEnd.toString(), "0");
 
     await program.methods
-      .stake(STAKE_AMOUNT)
+      .deposit(DEPOSIT_AMOUNT)
       .accounts({
         owner: USER_KEYPAIR.publicKey,
         pool: farmingPoolAddress,
@@ -411,11 +411,11 @@ describe("dual-farming", () => {
 
     assert.deepStrictEqual(
       userState.balanceStaked.toString(),
-      STAKE_AMOUNT.toString()
+      DEPOSIT_AMOUNT.toString()
     );
     assert.deepStrictEqual(
       stakingVaultBalance.value.amount,
-      STAKE_AMOUNT.toString()
+      DEPOSIT_AMOUNT.toString()
     );
   });
 
@@ -435,7 +435,7 @@ describe("dual-farming", () => {
     let poolState = await program.account.pool.fetch(farmingPoolAddress);
 
     await program.methods
-      .unstake(STAKE_AMOUNT)
+      .withdraw(DEPOSIT_AMOUNT)
       .accounts({
         owner: USER_KEYPAIR.publicKey,
         pool: farmingPoolAddress,
@@ -459,9 +459,9 @@ describe("dual-farming", () => {
     assert.deepStrictEqual(userState.balanceStaked.toString(), "0");
     assert.deepStrictEqual(stakingVaultBalance.value.amount, "0");
 
-    // Stake back the unstaked amount for further testing
+    // Deposit back the withdrawn amount for further testing
     await program.methods
-      .stake(STAKE_AMOUNT)
+      .deposit(DEPOSIT_AMOUNT)
       .accounts({
         owner: USER_KEYPAIR.publicKey,
         pool: farmingPoolAddress,
@@ -628,10 +628,10 @@ describe("dual-farming", () => {
         program.provider.connection.getTokenAccountBalance(userStakingATA),
         program.account.user.fetch(userStakingAddress),
       ]);
-    const unstakeHalfAmount = UNSTAKE_AMOUNT.div(new anchor.BN(2));
+    const withdrawHalfAmount = UNSTAKE_AMOUNT.div(new anchor.BN(2));
 
     await program.methods
-      .unstake(unstakeHalfAmount)
+      .withdraw(withdrawHalfAmount)
       .accounts({
         owner: USER_KEYPAIR.publicKey,
         pool: farmingPoolAddress,
@@ -918,7 +918,7 @@ describe("dual-farming", () => {
       ]);
 
     await program.methods
-      .unstake(beforeUserState.balanceStaked)
+      .withdraw(beforeUserState.balanceStaked)
       .accounts({
         owner: USER_KEYPAIR.publicKey,
         pool: farmingPoolAddress,

--- a/tests/dual-farming/single-reward.ts
+++ b/tests/dual-farming/single-reward.ts
@@ -31,7 +31,7 @@ function sleep(ms: number) {
   });
 }
 
-describe.only("dual-farming with single reward", () => {
+describe("dual-farming with single reward", () => {
   let stakingMint: anchor.web3.PublicKey = null;
   let rewardMint: anchor.web3.PublicKey = null;
 
@@ -161,7 +161,7 @@ describe.only("dual-farming with single reward", () => {
   });
 
   it("should stake to the pool", async () => {
-    const STAKE_AMOUNT = new anchor.BN(500 * TOKEN_MULTIPLIER);
+    const DEPOSIT_AMOUNT = new anchor.BN(500 * TOKEN_MULTIPLIER);
 
     await stakingToken.mintTo(
       userStakingATA,
@@ -185,7 +185,7 @@ describe.only("dual-farming with single reward", () => {
     const poolAccount = await program.account.pool.fetch(farmingPoolAddress);
 
     await program.methods
-      .stake(STAKE_AMOUNT)
+      .deposit(DEPOSIT_AMOUNT)
       .accounts({
         owner: USER_KEYPAIR.publicKey,
         pool: farmingPoolAddress,

--- a/tests/single-farming/Test.toml
+++ b/tests/single-farming/Test.toml
@@ -1,5 +1,5 @@
 extends = ["../Test.base.toml"]
 
 [scripts]
-test = "yarn run mocha -t 1000000 tests/single-farming"
+test = "yarn run mocha -t 1000000 tests/single-farming/single-farming.js"
 

--- a/tests/single-farming/user.js
+++ b/tests/single-farming/user.js
@@ -119,9 +119,9 @@ class User {
         return await this.program.account.pool.fetch(this.poolPubkey);
     }
     
-    async stakeTokensFull() {
+    async depositTokensFull() {
         let poolObject = await this.program.account.pool.fetch(this.poolPubkey);
-        await this.program.rpc.stakeFull(
+        await this.program.rpc.depositFull(
             {
                 accounts: {
                     // Stake instance.
@@ -137,9 +137,9 @@ class User {
         );
     }
 
-    async stakeTokens(amount) {
+    async depositTokens(amount) {
         let poolObject = await this.program.account.pool.fetch(this.poolPubkey);
-        await this.program.rpc.stake(
+        await this.program.rpc.deposit(
             new anchor.BN(amount),
             {
                 accounts: {
@@ -156,9 +156,9 @@ class User {
         );
     }
 
-    async unstakeTokens(amount) {
+    async withdrawTokens(amount) {
         let poolObject = await this.program.account.pool.fetch(this.poolPubkey);
-        await this.program.rpc.unstake(
+        await this.program.rpc.withdraw(
             new anchor.BN(amount),
             {
                 accounts: {

--- a/tests/staking/Test.toml
+++ b/tests/staking/Test.toml
@@ -1,4 +1,4 @@
 extends = ["../Test.base.toml"]
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/staking/**/*.ts"

--- a/tests/staking/staking.ts
+++ b/tests/staking/staking.ts
@@ -4,6 +4,9 @@ import * as anchor from "@project-serum/anchor";
 import { Program } from "@project-serum/anchor";
 import { Token, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Staking } from "../../target/types/staking";
+import { sleep } from "@project-serum/common";
+
+type Pubkey = anchor.web3.PublicKey;
 
 const provider = anchor.AnchorProvider.env();
 anchor.setProvider(provider);
@@ -12,22 +15,25 @@ const program = anchor.workspace.Staking as Program<Staking>;
 const admin = new anchor.web3.Keypair();
 const base = new anchor.web3.Keypair();
 const user = new anchor.web3.Keypair();
+const funder = new anchor.web3.Keypair();
+const newAdmin = new anchor.web3.Keypair();
 
-let tokenVault,
-  tokenMint,
-  vault,
-  nonce,
-  tokenVaultNonce,
-  lpMint,
-  lpMintNonce,
-  adminLp,
-  vaultLpToken,
-  adminToken,
-  userToken,
-  userLp;
+let tokenVault: Pubkey | null;
+let tokenMint: Token | null; // MER
+let vault: Pubkey | null;
+let vaultBump: number = 0;
+let tokenVaultNonce: number = 0;
+let lpMint: Pubkey | null; // xMER
+let lpMintNonce: number = 0;
+let vaultLpToken: Token | null;
+let userToken: Pubkey | null;
+let userLp: Pubkey | null;
+let adminToken: Pubkey | null;
+let funderToken: Pubkey | null;
+let newAdminToken: Pubkey | null;
 
 describe("staking", () => {
-  it("Vault Is initialized", async () => {
+  it("initialize vault", async () => {
     console.log("Program ID: ", program.programId.toString());
     console.log("Wallet: ", provider.wallet.publicKey.toString());
 
@@ -50,7 +56,7 @@ describe("staking", () => {
       TOKEN_PROGRAM_ID
     );
 
-    [vault, nonce] = await anchor.web3.PublicKey.findProgramAddress(
+    [vault, vaultBump] = await anchor.web3.PublicKey.findProgramAddress(
       [
         Buffer.from(anchor.utils.bytes.utf8.encode("vault")),
         tokenMint.publicKey.toBuffer(),
@@ -76,8 +82,9 @@ describe("staking", () => {
       program.programId
     );
 
-    const tx = await program.rpc.initializeVault(nonce, {
-      accounts: {
+    await program.methods
+      .initializeVault()
+      .accounts({
         vault,
         base: base.publicKey,
         tokenVault,
@@ -87,17 +94,57 @@ describe("staking", () => {
         tokenProgram: TOKEN_PROGRAM_ID,
         systemProgram: anchor.web3.SystemProgram.programId,
         rent: anchor.web3.SYSVAR_RENT_PUBKEY,
-      },
-      signers: [base, admin],
-    });
-    console.log("Your transaction signature", tx);
+      })
+      .signers([base, admin])
+      .rpc();
 
     let vaultAccount = await program.account.vault.fetch(vault);
-
-    console.log(vaultAccount);
+    assert.deepStrictEqual(
+      vaultAccount.admin.toBase58(),
+      admin.publicKey.toBase58()
+    );
+    assert.deepStrictEqual(
+      vaultAccount.base.toBase58(),
+      base.publicKey.toBase58()
+    );
+    assert.deepStrictEqual(
+      vaultAccount.funder.toBase58(),
+      anchor.web3.PublicKey.default.toBase58()
+    );
+    assert.deepStrictEqual(vaultAccount.totalAmount.toNumber(), 0);
+    assert.deepStrictEqual(vaultAccount.lpMint.toBase58(), lpMint.toBase58());
+    assert.deepStrictEqual(
+      vaultAccount.tokenMint.toBase58(),
+      tokenMint.publicKey.toBase58()
+    );
+    assert.deepStrictEqual(
+      vaultAccount.tokenVault.toBase58(),
+      tokenVault.toBase58()
+    );
+    assert.deepStrictEqual(vaultAccount.vaultBump, vaultBump);
   });
 
-  it("First Token Staked", async () => {
+  it("unable to initialize vault with same token mint", async () => {
+    let result = program.methods
+      .initializeVault()
+      .accounts({
+        vault,
+        base: base.publicKey,
+        tokenVault,
+        tokenMint: tokenMint.publicKey,
+        lpMint,
+        admin: admin.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        systemProgram: anchor.web3.SystemProgram.programId,
+        rent: anchor.web3.SYSVAR_RENT_PUBKEY,
+      })
+      .signers([base, admin])
+      .rpc();
+
+    await assert.rejects(result);
+  });
+
+  it("first time stake token successful", async () => {
     const tokenAmount = 100_000_000;
 
     // mints mer to user account
@@ -111,8 +158,10 @@ describe("staking", () => {
       user
     );
     userLp = await vaultLpToken.createAssociatedTokenAccount(user.publicKey);
-    const tx = await program.rpc.stake(new anchor.BN(tokenAmount), {
-      accounts: {
+
+    await program.methods
+      .stake(new anchor.BN(tokenAmount))
+      .accounts({
         vault,
         tokenVault,
         lpMint,
@@ -120,9 +169,9 @@ describe("staking", () => {
         userLp,
         userTransferAuthority: user.publicKey,
         tokenProgram: TOKEN_PROGRAM_ID,
-      },
-      signers: [user],
-    });
+      })
+      .signers([user])
+      .rpc();
 
     const userTokenAccount = await tokenMint.getAccountInfo(userToken);
     assert.strictEqual(0, userTokenAccount.amount.toNumber());
@@ -132,15 +181,22 @@ describe("staking", () => {
 
     const userLpTokenAccount = await vaultLpToken.getAccountInfo(userLp);
     assert.strictEqual(tokenAmount, userLpTokenAccount.amount.toNumber());
+
+    const vaultAccount = await program.account.vault.fetch(vault);
+    assert.strictEqual(
+      vaultAccount.totalAmount.toString(),
+      tokenAmount.toString()
+    );
   });
 
-  it("Second token Staked", async () => {
+  it("second time stake token successful", async () => {
     const tokenAmount = 200_000_000;
 
     await tokenMint.mintTo(userToken, admin, [], tokenAmount);
 
-    const tx = await program.rpc.stake(new anchor.BN(tokenAmount), {
-      accounts: {
+    await program.methods
+      .stake(new anchor.BN(tokenAmount))
+      .accounts({
         vault,
         tokenVault,
         lpMint,
@@ -148,9 +204,9 @@ describe("staking", () => {
         userLp,
         userTransferAuthority: user.publicKey,
         tokenProgram: TOKEN_PROGRAM_ID,
-      },
-      signers: [user],
-    });
+      })
+      .signers([user])
+      .rpc();
 
     const userTokenAccount = await tokenMint.getAccountInfo(userToken);
     assert.strictEqual(0, userTokenAccount.amount.toNumber());
@@ -160,33 +216,141 @@ describe("staking", () => {
       tokenAmount + 100_000_000,
       userLpTokenAccount.amount.toNumber()
     );
+
+    const vaultAccount = await program.account.vault.fetch(vault);
+    assert.strictEqual(
+      vaultAccount.totalAmount.toString(),
+      (100_000_000 + tokenAmount).toString()
+    );
   });
 
-  it("Reward Added to vault", async () => {
+  it("fail to add reward with unauthorized funder", async () => {
+    const tokenAmount = 200_000_000;
+    const unauthorizedFunder = new anchor.web3.Keypair();
+    await program.provider.connection
+      .requestAirdrop(unauthorizedFunder.publicKey, 1_000_000_000)
+      .then(async (sig) => program.provider.connection.confirmTransaction(sig));
+    const funderTokenAccount = await tokenMint.createAssociatedTokenAccount(
+      unauthorizedFunder.publicKey
+    );
+    await tokenMint.mintTo(funderTokenAccount, admin, [], tokenAmount);
+
+    let result = program.methods
+      .reward(new anchor.BN(tokenAmount))
+      .accounts({
+        vault,
+        tokenVault,
+        userToken: funderTokenAccount,
+        userTransferAuthority: unauthorizedFunder.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([unauthorizedFunder])
+      .rpc();
+
+    await assert.rejects(result);
+  });
+
+  it("change funder", async () => {
+    await program.methods
+      .changeFunder()
+      .accounts({
+        vault,
+        admin: admin.publicKey,
+        funder: funder.publicKey,
+      })
+      .signers([admin])
+      .rpc();
+    let vaultAccount = await program.account.vault.fetch(vault);
+    assert.strictEqual(
+      funder.publicKey.toString(),
+      vaultAccount.funder.toBase58()
+    );
+  });
+
+  it("admin add reward to vault", async () => {
     const tokenAmount = 200_000_000;
     adminToken = await tokenMint.createAssociatedTokenAccount(admin.publicKey);
     await tokenMint.mintTo(adminToken, admin, [], tokenAmount + 10);
 
-    const tx = await program.rpc.reward(new anchor.BN(tokenAmount), {
-      accounts: {
+    const beforeVaultAccount = await program.account.vault.fetch(vault);
+
+    await program.methods
+      .reward(new anchor.BN(tokenAmount))
+      .accounts({
         vault,
         tokenVault,
         userToken: adminToken,
         userTransferAuthority: admin.publicKey,
         tokenProgram: TOKEN_PROGRAM_ID,
-      },
-      signers: [admin],
-    });
+      })
+      .signers([admin])
+      .rpc();
 
     const vaultTokenAccount = await tokenMint.getAccountInfo(tokenVault);
     assert.strictEqual(500_000_000, vaultTokenAccount.amount.toNumber());
+
+    const afterVaultAccount = await program.account.vault.fetch(vault);
+    assert.strictEqual(afterVaultAccount.totalAmount.toString(), "500000000");
+    assert.strictEqual(
+      afterVaultAccount.lockedRewardTracker.lastReport.gt(
+        beforeVaultAccount.lockedRewardTracker.lastReport
+      ),
+      true
+    );
+    assert.strictEqual(
+      afterVaultAccount.lockedRewardTracker.lastUpdatedLockedReward.toString(),
+      tokenAmount.toString()
+    );
   });
 
-  it("Unstake", async () => {
+  it("funder add reward to vault", async () => {
+    const tokenAmount = 200_000_000;
+    funderToken = await tokenMint.createAssociatedTokenAccount(
+      funder.publicKey
+    );
+    await tokenMint.mintTo(funderToken, admin, [], tokenAmount + 10);
+
+    const beforeVaultAccount = await program.account.vault.fetch(vault);
+
+    await program.methods
+      .reward(new anchor.BN(tokenAmount))
+      .accounts({
+        vault,
+        tokenVault,
+        userToken: funderToken,
+        userTransferAuthority: funder.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([funder])
+      .rpc();
+
+    const vaultTokenAccount = await tokenMint.getAccountInfo(tokenVault);
+    assert.strictEqual(700_000_000, vaultTokenAccount.amount.toNumber());
+
+    const afterVaultAccount = await program.account.vault.fetch(vault);
+    assert.strictEqual(afterVaultAccount.totalAmount.toString(), "700000000");
+    assert.strictEqual(
+      afterVaultAccount.lockedRewardTracker.lastReport.gt(
+        beforeVaultAccount.lockedRewardTracker.lastReport
+      ),
+      true
+    );
+    assert.strictEqual(
+      afterVaultAccount.lockedRewardTracker.lastUpdatedLockedReward.gt(
+        beforeVaultAccount.lockedRewardTracker.lastUpdatedLockedReward
+      ),
+      true
+    );
+  });
+
+  it("unstake from vault", async () => {
     const lpAmount = 200_000_000;
 
-    const tx = await program.rpc.unstake(new anchor.BN(lpAmount), {
-      accounts: {
+    const beforeUserTokenBalance = await tokenMint.getAccountInfo(userToken);
+
+    await program.methods
+      .unstake(new anchor.BN(lpAmount))
+      .accounts({
         vault,
         tokenVault,
         lpMint,
@@ -194,29 +358,48 @@ describe("staking", () => {
         userLp,
         userTransferAuthority: user.publicKey,
         tokenProgram: TOKEN_PROGRAM_ID,
-      },
-      signers: [user],
-    });
+      })
+      .signers([user])
+      .rpc();
 
-    const userTokenAccount = await tokenMint.getAccountInfo(userToken);
-    console.log("user token amount: ", userTokenAccount.amount.toNumber());    
+    const afterUserTokenAccount = await tokenMint.getAccountInfo(userToken);
+    assert.deepStrictEqual(
+      afterUserTokenAccount.amount.gt(beforeUserTokenBalance.amount),
+      true
+    );
 
     const userLpTokenAccount = await vaultLpToken.getAccountInfo(userLp);
     assert.strictEqual(100_000_000, userLpTokenAccount.amount.toNumber());
   });
 
-  it("Update locked reward degradation", async () => {
+  it("fail to unstake others LP token", async () => {
+    let result = program.methods
+      .unstake(new anchor.BN(10))
+      .accounts({
+        vault,
+        tokenVault,
+        lpMint,
+        userToken,
+        userLp,
+        userTransferAuthority: user.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([admin]) // admin unstake user lp
+      .rpc();
+
+    await assert.rejects(result);
+  });
+
+  it("update locked reward degradation", async () => {
     let newRewardDegradation = 200000000000; //5 seconds
-    const tx = await program.rpc.updateLockedRewardDegradation(
-      new anchor.BN(newRewardDegradation),
-      {
-        accounts: {
-          vault,
-          admin: admin.publicKey,
-        },
-        signers: [admin],
-      }
-    );
+    await program.methods
+      .updateLockedRewardDegradation(new anchor.BN(newRewardDegradation))
+      .accounts({
+        vault,
+        admin: admin.publicKey,
+      })
+      .signers([admin])
+      .rpc();
 
     let vaultAccount = await program.account.vault.fetch(vault);
     assert.strictEqual(
@@ -225,13 +408,14 @@ describe("staking", () => {
     );
   });
 
-  it("Unstake after waiting", async () => {
-    // wait
+  it("unstake after waiting for profit drip", async () => {
+    // wait 1 seconds
     await wait(1);
-    var lpAmount = 50_000_000;
+    let lpAmount = 50_000_000;
 
-    var tx = await program.rpc.unstake(new anchor.BN(lpAmount), {
-      accounts: {
+    await program.methods
+      .unstake(new anchor.BN(lpAmount))
+      .accounts({
         vault,
         tokenVault,
         lpMint,
@@ -239,9 +423,9 @@ describe("staking", () => {
         userLp,
         userTransferAuthority: user.publicKey,
         tokenProgram: TOKEN_PROGRAM_ID,
-      },
-      signers: [user],
-    });
+      })
+      .signers([user])
+      .rpc();
 
     var userTokenAccount = await tokenMint.getAccountInfo(userToken);
     console.log(userTokenAccount.amount.toNumber());
@@ -249,11 +433,13 @@ describe("staking", () => {
     var userLpTokenAccount = await vaultLpToken.getAccountInfo(userLp);
     assert.strictEqual(50_000_000, userLpTokenAccount.amount.toNumber());
 
+    // wait 4 seconds
     await wait(4);
-    var lpAmount = 50_000_000;
 
-    var tx = await program.rpc.unstake(new anchor.BN(lpAmount), {
-      accounts: {
+    // after 5 seconds, profit is fully dripped
+    await program.methods
+      .unstake(new anchor.BN(lpAmount))
+      .accounts({
         vault,
         tokenVault,
         lpMint,
@@ -261,52 +447,286 @@ describe("staking", () => {
         userLp,
         userTransferAuthority: user.publicKey,
         tokenProgram: TOKEN_PROGRAM_ID,
-      },
-      signers: [user],
-    });
+      })
+      .signers([user])
+      .rpc();
+
+    const vaultAccount = await program.account.vault.fetch(vault);
+    // only 1 staker, and profit was fully dripped
+    assert.deepStrictEqual(vaultAccount.totalAmount.toNumber(), 0);
 
     var userTokenAccount = await tokenMint.getAccountInfo(userToken);
-    assert.strictEqual(500_000_000, userTokenAccount.amount.toNumber());
+    assert.strictEqual(700_000_000, userTokenAccount.amount.toNumber());
 
     var userLpTokenAccount = await vaultLpToken.getAccountInfo(userLp);
     assert.strictEqual(0, userLpTokenAccount.amount.toNumber());
   });
 
-  it("Change funder", async() => {
-    let newFunder = new anchor.web3.Keypair();
-    var tx = await program.rpc.changeFunder (
-        {
-          accounts: {
-            vault,
-            admin: admin.publicKey,
-            funder: newFunder.publicKey
-          },
-          signers: [admin]
-        }
-    )
-    let vaultAccount = await program.account.vault.fetch(
-        vault
-    );
-    assert.strictEqual(newFunder.publicKey.toString(), vaultAccount.funder.toBase58());
-  })
+  it("vault functional after depleted", async () => {
+    const tokenAmount = 200_000_000;
 
-    it('Transfer admin', async () => {
-        let newAdmin = new anchor.web3.Keypair();
-        var tx = await program.rpc.transferAdmin (
-            {
-                accounts: {
-                    vault,
-                    admin: admin.publicKey,
-                    newAdmin: newAdmin.publicKey
-                },
-                signers: [admin, newAdmin]
-            }
-        )
-        let vaultAccount = await program.account.vault.fetch(
-            vault
+    // Make sure it is depleted
+    var [vaultAccount, lpMintSupply] = await Promise.all([
+      program.account.vault.fetch(vault),
+      program.provider.connection.getTokenSupply(lpMint),
+    ]);
+
+    assert.deepStrictEqual(vaultAccount.totalAmount.toString(), "0");
+    assert.deepStrictEqual(lpMintSupply.value.amount, "0");
+
+    await program.methods
+      .stake(new anchor.BN(tokenAmount))
+      .accounts({
+        vault,
+        tokenVault,
+        lpMint,
+        userToken,
+        userLp,
+        userTransferAuthority: user.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([user])
+      .rpc();
+
+    var [userLpBalance, lpMintSupply] = await Promise.all([
+      vaultLpToken.getAccountInfo(userLp),
+      program.provider.connection.getTokenSupply(lpMint),
+    ]);
+
+    // Depleted vault mint correct lp amount
+    assert.deepStrictEqual(
+      userLpBalance.amount.toString(),
+      tokenAmount.toString()
+    );
+    assert.deepStrictEqual(
+      lpMintSupply.value.amount,
+      userLpBalance.amount.toString()
+    );
+
+    // Admin deposit some reward
+    await tokenMint.mintTo(adminToken, admin, [], tokenAmount);
+    await program.methods
+      .reward(new anchor.BN(tokenAmount))
+      .accounts({
+        vault,
+        tokenVault,
+        userToken: adminToken,
+        userTransferAuthority: admin.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([admin])
+      .rpc();
+
+    let seconds = 5;
+    while (seconds-- > 0) {
+      await sleep(1);
+
+      // withdraw all liquidity, with partially dripped profit
+      var userLpBalance = await vaultLpToken.getAccountInfo(userLp);
+      await program.methods
+        .unstake(userLpBalance.amount)
+        .accounts({
+          vault,
+          tokenVault,
+          lpMint,
+          userToken,
+          userLp,
+          userTransferAuthority: user.publicKey,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .signers([user])
+        .rpc();
+
+      var [userLpBalance, lpMintSupply, vaultAccount] = await Promise.all([
+        vaultLpToken.getAccountInfo(userLp),
+        program.provider.connection.getTokenSupply(lpMint),
+        program.account.vault.fetch(vault),
+      ]);
+
+      assert.deepStrictEqual(userLpBalance.amount.toString(), "0");
+      assert.deepStrictEqual(lpMintSupply.value.amount, "0");
+
+      if (seconds > 0) {
+        assert.deepStrictEqual(
+          vaultAccount.totalAmount.gt(new anchor.BN(0)),
+          true
         );
-        assert.strictEqual(newAdmin.publicKey.toString(), vaultAccount.admin.toBase58());
-    });
+
+        // Stake again, to get unfinished dripping profit
+        await program.methods
+          .stake(new anchor.BN(tokenAmount))
+          .accounts({
+            vault,
+            tokenVault,
+            lpMint,
+            userToken,
+            userLp,
+            userTransferAuthority: user.publicKey,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          })
+          .signers([user])
+          .rpc();
+
+        var [userLpBalance, lpMintSupply, vaultAccount] = await Promise.all([
+          vaultLpToken.getAccountInfo(userLp),
+          program.provider.connection.getTokenSupply(lpMint),
+          program.account.vault.fetch(vault),
+        ]);
+
+        // Make sure it's minting LP upon staking
+        assert.deepStrictEqual(
+          userLpBalance.amount.toString(),
+          lpMintSupply.value.amount.toString()
+        );
+
+        // Virtual price > 1 when it is fully unlocked
+        const precision = new anchor.BN(100_000_000);
+        const virtualPrice = vaultAccount.totalAmount
+          .mul(precision)
+          .div(new anchor.BN(lpMintSupply.value.amount));
+
+        assert.deepStrictEqual(virtualPrice.gt(precision), true);
+      }
+    }
+  });
+
+  it("fail to stake 0 amount", async () => {
+    let result = program.methods
+      .stake(new anchor.BN(0))
+      .accounts({
+        vault,
+        tokenVault,
+        lpMint,
+        userToken,
+        userLp,
+        userTransferAuthority: user.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([user])
+      .rpc();
+    await assert.rejects(result);
+  });
+
+  it("transfer admin", async () => {
+    await program.methods
+      .transferAdmin()
+      .accounts({
+        vault,
+        admin: admin.publicKey,
+        newAdmin: newAdmin.publicKey,
+      })
+      .signers([admin, newAdmin])
+      .rpc();
+    let vaultAccount = await program.account.vault.fetch(vault);
+    assert.strictEqual(
+      newAdmin.publicKey.toBase58(),
+      vaultAccount.admin.toBase58()
+    );
+
+    // new admin able to perform all admin related function
+    const tokenAmount = 200_000_000;
+
+    await program.provider.connection
+      .requestAirdrop(newAdmin.publicKey, 1_000_000_000)
+      .then((sig) => program.provider.connection.confirmTransaction(sig));
+
+    newAdminToken = await tokenMint.createAssociatedTokenAccount(
+      newAdmin.publicKey
+    );
+
+    await tokenMint.mintTo(newAdminToken, admin, [], tokenAmount);
+
+    await program.methods
+      .reward(new anchor.BN(tokenAmount))
+      .accounts({
+        vault,
+        tokenVault,
+        userToken: newAdminToken,
+        userTransferAuthority: newAdmin.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([newAdmin])
+      .rpc();
+
+    let newFunder = new anchor.web3.Keypair();
+    await program.methods
+      .changeFunder()
+      .accounts({
+        admin: newAdmin.publicKey,
+        funder: newFunder.publicKey,
+        vault,
+      })
+      .signers([newAdmin])
+      .rpc();
+
+    const newProfitDegradation = 1_000_000_000_000; // 1 seconds
+    await program.methods
+      .updateLockedRewardDegradation(new anchor.BN(newProfitDegradation))
+      .accounts({
+        admin: newAdmin.publicKey,
+        vault,
+      })
+      .signers([newAdmin])
+      .rpc();
+
+    // wait for fully drip
+    await wait(1);
+  });
+
+  it("vault still functional after admin changed", async () => {
+    const tokenAmount = 100_000_000;
+
+    await program.methods
+      .stake(new anchor.BN(tokenAmount))
+      .accounts({
+        vault,
+        tokenVault,
+        lpMint,
+        userToken,
+        userLp,
+        userTransferAuthority: user.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([user])
+      .rpc();
+
+    const beforeVaultAccount = await program.account.vault.fetch(vault);
+    const beforeUserTokenAccount = await tokenMint.getAccountInfo(userToken);
+    const beforeUserLpTokenAccount = await vaultLpToken.getAccountInfo(userLp);
+
+    assert.deepStrictEqual(
+      beforeUserLpTokenAccount.amount.toString(),
+      beforeVaultAccount.totalAmount.toString()
+    );
+
+    await program.methods
+      .unstake(beforeUserLpTokenAccount.amount)
+      .accounts({
+        vault,
+        tokenVault,
+        lpMint,
+        userToken,
+        userLp,
+        userTransferAuthority: user.publicKey,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([user])
+      .rpc();
+
+    const userLpTokenAccount = await vaultLpToken.getAccountInfo(userLp);
+    assert.deepStrictEqual(userLpTokenAccount.amount.toString(), "0");
+
+    const afterVaultAccount = await program.account.vault.fetch(vault);
+    assert.deepStrictEqual(afterVaultAccount.totalAmount.toString(), "0");
+
+    const afterUserTokenAccount = await tokenMint.getAccountInfo(userToken);
+    assert.deepStrictEqual(
+      beforeUserTokenAccount.amount
+        .add(beforeVaultAccount.totalAmount)
+        .eq(afterUserTokenAccount.amount),
+      true
+    );
+  });
 });
 
 async function wait(seconds) {


### PR DESCRIPTION
- Rename `stake` & `unstake` to `deposit` & `withdraw` for farm program to avoid confusion
- Add test cases for staking program
- Fix some test script running twice
- Fix dos when staking program lp_supply = 0
- Fix invalid parameter for test case `test_stake_and_withdraw`